### PR TITLE
Use FpGeteuid to check for admin rights

### DIFF
--- a/src/tparted.lpr
+++ b/src/tparted.lpr
@@ -4,7 +4,7 @@ program TParted;
 
 uses
   {$ifdef UNIX}
-  CThreads, cwstring, Unix,
+  CThreads, cwstring, Unix, BaseUnix,
   {$endif}
   SysUtils, Classes, Types,
   FileSystem,
@@ -27,7 +27,7 @@ var
   Report: String;
 
 begin
-  if GetEnvironmentVariable('SUDO_UID') = '' then
+  if FpGeteuid() <> 0 then
   begin
     Writeln(StdErr, 'This program requires admin rights to work properly.');
     Halt(1);


### PR DESCRIPTION
It's better to use FpGeteuid() rather than checking an environment variable which will not work on a console root login or if root is obtained by running "sudo su -".