### PR TITLE
Append p to mmcblk devices as well

### DIFF
--- a/fp.dir
+++ b/fp.dir
@@ -1,0 +1,1 @@
+Comment=Do NOT delete this file!!!

--- a/src/parted.devices.pas
+++ b/src/parted.devices.pas
@@ -160,8 +160,8 @@ end;
 
 function TPartedPartition.GetPartitionPath: String;
 begin
-  if Pos('nvme', Self.Device^.Path) > 0 then
-    Result := Self.Device^.Path + 'p' // NVME
+  if (Pos('nvme', Self.Device^.Path) > 0) or (Pos('mmcblk', Self.Device^.Path) > 0) then
+    Result := Self.Device^.Path + 'p'
   else
     Result := Self.Device^.Path; // SATA
   //


### PR DESCRIPTION
We need to append `p` to `mmcblk` devices (SD Cards) as well.  I have one mounted on my laptop that looks like this:

```
/dev/mmcblk0     179:0    0  29.7G  0 disk 
└─/dev/mmcblk0p1 179:1    0  29.7G  0 part /media/danny/PHONE
```

BTW, I checked whether there might be other device types that have this naming convention and all I could find was this:

https://www.man7.org/linux/man-pages/man4/cciss.4.html

which uses this convention with a subfolder: `/dev/cciss/c0d0p1`.  So it might not work without modification, but will be difficult to test without access to the HP hardware.